### PR TITLE
Remove duplicate CloudKitService

### DIFF
--- a/DataService.swift
+++ b/DataService.swift
@@ -342,40 +342,4 @@ enum DataServiceError: LocalizedError {
     }
 }
 
-// MARK: - CloudKit Service
-class CloudKitService {
-    private let container: CKContainer
-    private let database: CKDatabase
-    
-    init() {
-        self.container = CKContainer.default()
-        self.database = container.privateCloudDatabase
-    }
-    
-    func checkAccountStatus() -> AnyPublisher<CKAccountStatus, Error> {
-        Future { [weak self] promise in
-            self?.container.accountStatus { status, error in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(status))
-                }
-            }
-        }
-        .eraseToAnyPublisher()
-    }
-    
-    func requestPermissions() -> AnyPublisher<CKContainer.ApplicationPermissionStatus, Error> {
-        Future { [weak self] promise in
-            self?.container.requestApplicationPermission(.userDiscoverability) { status, error in
-                if let error = error {
-                    promise(.failure(error))
-                } else {
-                    promise(.success(status))
-                }
-            }
-        }
-        .eraseToAnyPublisher()
-    }
-}
 


### PR DESCRIPTION
## Summary
- remove outdated CloudKitService definition from DataService

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6882b2a570948330bf4df4e24d7c9c86