### PR TITLE
Ensure CoreData thread safety

### DIFF
--- a/CoreDataServiceThreadSafetyTests.swift
+++ b/CoreDataServiceThreadSafetyTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+import Combine
+import CoreData
+@testable import IntraHabits
+
+final class CoreDataServiceThreadSafetyTests: XCTestCase {
+    var persistenceController: PersistenceController!
+    var service: CoreDataService!
+    var cancellables = Set<AnyCancellable>()
+
+    override func setUpWithError() throws {
+        persistenceController = PersistenceController(inMemory: true)
+        service = CoreDataService(container: persistenceController.container)
+    }
+
+    override func tearDownWithError() throws {
+        cancellables.removeAll()
+        service = nil
+        persistenceController = nil
+    }
+
+    func testCreateActivityOnBackgroundQueue() {
+        let expectation = XCTestExpectation(description: "Create activity on background queue")
+
+        DispatchQueue.global(qos: .background).async {
+            self.service.createActivity(name: "BG", type: .numeric, color: "#000000")
+                .sink(receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        XCTFail("Failed with \(error)")
+                    }
+                    expectation.fulfill()
+                }, receiveValue: { _ in })
+                .store(in: &self.cancellables)
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+}


### PR DESCRIPTION
## Summary
- use `context.perform` in `CoreDataService` for all fetch/save operations
- add basic thread-safety test for creating activities on a background queue

## Testing
- `xcodebuild test -scheme IntraHabits -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6882b2a6ab148330bd42dd23b2b7da62