### PR TITLE
Connect AddActivityViewModel with StoreKit

### DIFF
--- a/AddActivityView.swift
+++ b/AddActivityView.swift
@@ -250,9 +250,9 @@ class AddActivityViewModel: ObservableObject {
         
         do {
             let existingActivities = try context.fetch(request)
-            
-            // TODO: Check if user has premium subscription
-            let hasUnlimitedActivities = false // This will be replaced with actual subscription check
+
+            // Check if user has unlocked unlimited activities
+            let hasUnlimitedActivities = StoreKitService.shared.hasUnlimitedActivities
             
             if existingActivities.count >= 5 && !hasUnlimitedActivities {
                 shouldShowPaywall = true


### PR DESCRIPTION
## Summary
- hook AddActivityViewModel to StoreKitService
- remove placeholder logic for premium check
- show paywall when exceeding free activity limit

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme IntraHabits -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882b6e6c24c8330ac2c814fd870e443