### PR TITLE
Replace prints with logging and add alerts

### DIFF
--- a/ActivityCard.swift
+++ b/ActivityCard.swift
@@ -205,7 +205,7 @@ class ActivityCardViewModel: ObservableObject {
             impactFeedback.impactOccurred()
             
         } catch {
-            print("Error saving session: \(error)")
+            AppLogger.error("Error saving session: \(error)")
         }
     }
     

--- a/ActivityDetailView.swift
+++ b/ActivityDetailView.swift
@@ -61,6 +61,13 @@ struct ActivityDetailView: View {
         } message: {
             Text("activity.delete.confirmation.message")
         }
+        .alert("Error", isPresented: .constant(viewModel.errorMessage != nil)) {
+            Button("OK") { viewModel.errorMessage = nil }
+        } message: {
+            if let errorMessage = viewModel.errorMessage {
+                Text(errorMessage)
+            }
+        }
     }
     
     // MARK: - Header Section
@@ -266,7 +273,8 @@ struct ActivityDetailView: View {
             try viewContext.save()
             dismiss()
         } catch {
-            print("Error deleting activity: \(error)")
+            AppLogger.error("Error deleting activity: \(error)")
+            viewModel.errorMessage = error.localizedDescription
         }
     }
 }
@@ -309,6 +317,7 @@ class ActivityDetailViewModel: ObservableObject {
     @Published var currentStreak: Int = 0
     @Published var longestStreak: Int = 0
     @Published var recentSessions: [ActivitySession] = []
+    @Published var errorMessage: String?
     
     private var activity: Activity?
     private var viewContext: NSManagedObjectContext?
@@ -352,9 +361,10 @@ class ActivityDetailViewModel: ObservableObject {
             // Haptic feedback
             let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
             impactFeedback.impactOccurred()
-            
+
         } catch {
-            print("Error saving session: \(error)")
+            AppLogger.error("Error saving session: \(error)")
+            errorMessage = error.localizedDescription
         }
     }
     
@@ -387,7 +397,8 @@ class ActivityDetailViewModel: ObservableObject {
         do {
             recentSessions = try context.fetch(request)
         } catch {
-            print("Error loading recent sessions: \(error)")
+            AppLogger.error("Error loading recent sessions: \(error)")
+            errorMessage = error.localizedDescription
             recentSessions = []
         }
     }

--- a/ActivityListViewModel.swift
+++ b/ActivityListViewModel.swift
@@ -97,7 +97,7 @@ class ActivityCardViewModel: ObservableObject {
             let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
             impactFeedback.impactOccurred()
         } catch {
-            print("Error saving session: \(error)")
+            AppLogger.error("Error saving session: \(error)")
         }
     }
     
@@ -124,7 +124,7 @@ class ActivityCardViewModel: ObservableObject {
                 formattedDuration = formatDuration(totalDuration)
             }
         } catch {
-            print("Error fetching sessions: \(error)")
+            AppLogger.error("Error fetching sessions: \(error)")
         }
     }
     

--- a/ActivitySession+Extensions.swift
+++ b/ActivitySession+Extensions.swift
@@ -238,7 +238,7 @@ extension ActivitySession {
             let sessions = try context.fetch(request)
             return sessions.reduce(0) { $0 + $1.duration }
         } catch {
-            print("Error fetching sessions for total duration: \(error)")
+            AppLogger.error("Error fetching sessions for total duration: \(error)")
             return 0
         }
     }
@@ -250,7 +250,7 @@ extension ActivitySession {
             let sessions = try context.fetch(request)
             return sessions.reduce(0) { $0 + $1.numericValue }
         } catch {
-            print("Error fetching sessions for total count: \(error)")
+            AppLogger.error("Error fetching sessions for total count: \(error)")
             return 0
         }
     }
@@ -265,7 +265,7 @@ extension ActivitySession {
             let totalDuration = sessions.reduce(0) { $0 + $1.duration }
             return totalDuration / Double(sessions.count)
         } catch {
-            print("Error fetching sessions for average duration: \(error)")
+            AppLogger.error("Error fetching sessions for average duration: \(error)")
             return 0
         }
     }
@@ -276,7 +276,7 @@ extension ActivitySession {
         do {
             return try context.count(for: request)
         } catch {
-            print("Error counting sessions: \(error)")
+            AppLogger.error("Error counting sessions: \(error)")
             return 0
         }
     }

--- a/CalendarView.swift
+++ b/CalendarView.swift
@@ -386,7 +386,7 @@ class CalendarViewModel: ObservableObject {
         do {
             monthSessions = try context.fetch(request)
         } catch {
-            print("Error loading month sessions: \(error)")
+            AppLogger.error("Error loading month sessions: \(error)")
             monthSessions = []
         }
     }
@@ -406,7 +406,7 @@ class CalendarViewModel: ObservableObject {
         do {
             selectedDateSessions = try context.fetch(request)
         } catch {
-            print("Error loading date sessions: \(error)")
+            AppLogger.error("Error loading date sessions: \(error)")
             selectedDateSessions = []
         }
     }

--- a/CloudKitService.swift
+++ b/CloudKitService.swift
@@ -61,7 +61,7 @@ class CloudKitService: ObservableObject {
         do {
             return try await container.accountStatus()
         } catch {
-            print("Error checking CloudKit account status: \(error)")
+            AppLogger.error("Error checking CloudKit account status: \(error)")
             return .couldNotDetermine
         }
     }
@@ -99,7 +99,7 @@ class CloudKitService: ObservableObject {
         } catch {
             syncError = error
             syncStatus = .failed
-            print("Sync failed: \(error)")
+            AppLogger.error("Sync failed: \(error)")
         }
     }
     
@@ -196,7 +196,7 @@ class CloudKitService: ObservableObject {
             case .success(let record):
                 try await processActivityRecord(record)
             case .failure(let error):
-                print("Error downloading activity record: \(error)")
+                AppLogger.error("Error downloading activity record: \(error)")
             }
         }
     }
@@ -212,7 +212,7 @@ class CloudKitService: ObservableObject {
             case .success(let record):
                 try await processSessionRecord(record)
             case .failure(let error):
-                print("Error downloading session record: \(error)")
+                AppLogger.error("Error downloading session record: \(error)")
             }
         }
     }
@@ -288,7 +288,7 @@ class CloudKitService: ObservableObject {
                 try context.save()
                 
             } catch {
-                print("Error processing activity record: \(error)")
+                AppLogger.error("Error processing activity record: \(error)")
             }
         }
     }
@@ -333,7 +333,7 @@ class CloudKitService: ObservableObject {
                 try context.save()
                 
             } catch {
-                print("Error processing session record: \(error)")
+                AppLogger.error("Error processing session record: \(error)")
             }
         }
     }

--- a/EditActivityView.swift
+++ b/EditActivityView.swift
@@ -246,7 +246,7 @@ class EditActivityViewModel: ObservableObject {
             let sessions = try context.fetch(request)
             hasExistingSessions = !sessions.isEmpty
         } catch {
-            print("Error checking for existing sessions: \(error)")
+            AppLogger.error("Error checking for existing sessions: \(error)")
             hasExistingSessions = false
         }
     }

--- a/Logging.swift
+++ b/Logging.swift
@@ -1,0 +1,15 @@
+import Foundation
+import os
+
+enum AppLogger {
+    private static let subsystem = Bundle.main.bundleIdentifier ?? "IntraHabits"
+    private static let logger = Logger(subsystem: subsystem, category: "general")
+
+    static func info(_ message: String) {
+        logger.info("\(message, privacy: .public)")
+    }
+
+    static func error(_ message: String) {
+        logger.error("\(message, privacy: .public)")
+    }
+}

--- a/NavigationCoordinator.swift
+++ b/NavigationCoordinator.swift
@@ -95,13 +95,13 @@ class NavigationCoordinator: ObservableObject {
                let activityId = UUID(uuidString: activityIdString) {
                 // Navigate to specific activity
                 // This would require fetching the activity from Core Data
-                print("Deep link to activity: \(activityId)")
+                AppLogger.info("Deep link to activity: \(activityId)")
             }
         case "timer":
             if let activityIdString = components.queryItems?.first(where: { $0.name == "id" })?.value,
                let activityId = UUID(uuidString: activityIdString) {
                 // Navigate to timer for specific activity
-                print("Deep link to timer for activity: \(activityId)")
+                AppLogger.info("Deep link to timer for activity: \(activityId)")
             }
         case "add":
             presentAddActivity()

--- a/StatisticsView.swift
+++ b/StatisticsView.swift
@@ -501,7 +501,7 @@ class StatisticsViewModel: ObservableObject {
             calculateStreakData()
             
         } catch {
-            print("Error loading statistics: \(error)")
+            AppLogger.error("Error loading statistics: \(error)")
         }
     }
     
@@ -628,7 +628,7 @@ class StatisticsViewModel: ObservableObject {
             }.sorted { $0.currentStreak > $1.currentStreak }
             
         } catch {
-            print("Error calculating streak data: \(error)")
+            AppLogger.error("Error calculating streak data: \(error)")
         }
     }
     

--- a/StoreKitService.swift
+++ b/StoreKitService.swift
@@ -45,7 +45,7 @@ class StoreKitService: ObservableObject {
             
         } catch {
             errorMessage = "Failed to load products: \(error.localizedDescription)"
-            print("Error loading products: \(error)")
+            AppLogger.error("Error loading products: \(error)")
         }
         
         isLoading = false
@@ -85,7 +85,7 @@ class StoreKitService: ObservableObject {
             
         } catch {
             errorMessage = "Purchase failed: \(error.localizedDescription)"
-            print("Purchase error: \(error)")
+            AppLogger.error("Purchase error: \(error)")
             return .failed(error)
         }
     }
@@ -107,7 +107,7 @@ class StoreKitService: ObservableObject {
             
         } catch {
             errorMessage = "Restore failed: \(error.localizedDescription)"
-            print("Restore error: \(error)")
+            AppLogger.error("Restore error: \(error)")
             return .failed(error)
         }
     }
@@ -130,7 +130,7 @@ class StoreKitService: ObservableObject {
                 let transaction = try checkVerified(result)
                 purchasedProducts.insert(transaction.productID)
             } catch {
-                print("Transaction verification failed: \(error)")
+                AppLogger.error("Transaction verification failed: \(error)")
             }
         }
         
@@ -156,7 +156,7 @@ class StoreKitService: ObservableObject {
                     
                     await transaction.finish()
                 } catch {
-                    print("Transaction update error: \(error)")
+                    AppLogger.error("Transaction update error: \(error)")
                 }
             }
         }

--- a/TimerView.swift
+++ b/TimerView.swift
@@ -52,6 +52,13 @@ struct TimerView: View {
         } message: {
             Text("timer.save.message")
         }
+        .alert("Error", isPresented: .constant(viewModel.errorMessage != nil)) {
+            Button("OK") { viewModel.errorMessage = nil }
+        } message: {
+            if let errorMessage = viewModel.errorMessage {
+                Text(errorMessage)
+            }
+        }
     }
     
     // MARK: - Header Section
@@ -241,6 +248,7 @@ class TimerViewModel: ObservableObject {
     @Published var timerState: TimerState = .stopped
     @Published var todaysFormattedTotal = "0m"
     @Published var showingSaveConfirmation = false
+    @Published var errorMessage: String?
     
     private var activity: Activity?
     private var viewContext: NSManagedObjectContext?
@@ -342,7 +350,8 @@ class TimerViewModel: ObservableObject {
             notificationFeedback.notificationOccurred(.success)
             
         } catch {
-            print("Error saving timer session: \(error)")
+            AppLogger.error("Error saving timer session: \(error)")
+            errorMessage = error.localizedDescription
         }
     }
     

--- a/WidgetDataService.swift
+++ b/WidgetDataService.swift
@@ -23,7 +23,7 @@ class WidgetDataService: ObservableObject {
         
         container.loadPersistentStores { _, error in
             if let error = error {
-                print("Widget Core Data error: \(error)")
+                AppLogger.error("Widget Core Data error: \(error)")
             }
         }
         


### PR DESCRIPTION
## Summary
- add a simple `AppLogger` wrapper around `os.Logger`
- use `AppLogger` instead of `print` across the project
- surface errors in `ActivityDetailView` and `TimerView` with alerts

## Testing
- `swift test` *(fails: no Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6882b6e766388330ad0183c1e06fd354