### PR TITLE
Fix WidgetTimerService init

### DIFF
--- a/WidgetTimerService.swift
+++ b/WidgetTimerService.swift
@@ -7,15 +7,19 @@ class WidgetTimerService: ObservableObject {
     
     private let userDefaults: UserDefaults
     private let appGroupIdentifier = "group.com.intrahabits.shared"
+    private(set) var isEnabled = true
     
     private var timerStates: [String: WidgetTimerState] = [:]
     
     private init() {
-        guard let sharedDefaults = UserDefaults(suiteName: appGroupIdentifier) else {
-            fatalError("Unable to create shared UserDefaults")
+        if let sharedDefaults = UserDefaults(suiteName: appGroupIdentifier) {
+            self.userDefaults = sharedDefaults
+            loadTimerStates()
+        } else {
+            self.userDefaults = UserDefaults.standard
+            self.isEnabled = false
+            print("WidgetTimerService: Unable to create shared UserDefaults. Timer widgets are disabled.")
         }
-        self.userDefaults = sharedDefaults
-        loadTimerStates()
     }
     
     // MARK: - Timer State Management


### PR DESCRIPTION
## Summary
- handle failure to access app group defaults gracefully

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882b70a4d8483308cc303fcf69bf6ca