### PR TITLE
Enforce activity limit with StoreKit check

### DIFF
--- a/CoreDataServiceActivityLimitTests.swift
+++ b/CoreDataServiceActivityLimitTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+import CoreData
+@testable import IntraHabits
+
+final class CoreDataServiceActivityLimitTests: XCTestCase {
+    var persistenceController: PersistenceController!
+    var service: CoreDataService!
+
+    override func setUpWithError() throws {
+        persistenceController = PersistenceController(inMemory: true)
+        service = CoreDataService(container: persistenceController.container)
+        StoreKitService.shared.purchasedProductIDs.removeAll()
+    }
+
+    override func tearDownWithError() throws {
+        StoreKitService.shared.purchasedProductIDs.removeAll()
+        service = nil
+        persistenceController = nil
+    }
+
+    func testActivityLimitEnforcedWithoutPurchase() async throws {
+        for i in 0..<5 {
+            _ = try await service.createActivity(name: "A\\(i)", type: .numeric, color: "#CD3A2E")
+        }
+
+        do {
+            _ = try await service.createActivity(name: "Extra", type: .numeric, color: "#CD3A2E")
+            XCTFail("Expected limit error")
+        } catch DataServiceError.activityLimitReached {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testActivityLimitIgnoredWithPurchase() async throws {
+        StoreKitService.shared.purchasedProductIDs.insert("com.intrahabits.unlimited_activities")
+
+        for i in 0..<6 {
+            _ = try await service.createActivity(name: "A\\(i)", type: .numeric, color: "#CD3A2E")
+        }
+    }
+}

--- a/DataService.swift
+++ b/DataService.swift
@@ -46,9 +46,9 @@ class CoreDataService: DataServiceProtocol {
             countRequest.predicate = NSPredicate(format: "isActive == %@", NSNumber(value: true))
             let existingCount = try self.context.count(for: countRequest)
 
-            // TODO: Check premium subscription status from StoreKitService
-            let hasUnlimitedActivities = StoreKitService.shared.hasUnlimitedActivities
-            if existingCount >= 5 && !hasUnlimitedActivities {
+            // Verify purchase status before enforcing the free activity limit
+            let storeKitService = StoreKitService.shared
+            if !storeKitService.canAddMoreActivities(currentCount: existingCount) {
                 throw DataServiceError.activityLimitReached
             }
 


### PR DESCRIPTION
## Summary
- verify purchase status before applying free activity limit
- add tests covering premium limit logic

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882c4d09b4c8330bd3ed9312170b728