### PR TITLE
Add sessions list navigation

### DIFF
--- a/ActivityDetailView.swift
+++ b/ActivityDetailView.swift
@@ -10,6 +10,7 @@ struct ActivityDetailView: View {
     @StateObject private var viewModel = ActivityDetailViewModel()
     @State private var showingEditActivity = false
     @State private var showingDeleteConfirmation = false
+    @State private var showingSessionsList = false
     
     var body: some View {
         NavigationView {
@@ -51,6 +52,10 @@ struct ActivityDetailView: View {
         }
         .sheet(isPresented: $showingEditActivity) {
             EditActivityView(activity: activity)
+                .environment(\.managedObjectContext, viewContext)
+        }
+        .sheet(isPresented: $showingSessionsList) {
+            ActivitySessionsListView(activity: activity)
                 .environment(\.managedObjectContext, viewContext)
         }
         .alert("activity.delete.confirmation.title", isPresented: $showingDeleteConfirmation) {
@@ -213,7 +218,7 @@ struct ActivityDetailView: View {
                 Spacer()
                 
                 Button("activity.detail.view_all") {
-                    // TODO: Navigate to sessions list
+                    showingSessionsList = true
                 }
                 .font(DesignSystem.Typography.subheadline)
                 .foregroundColor(DesignSystem.Colors.primary)

--- a/ActivitySessionsListView.swift
+++ b/ActivitySessionsListView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+import CoreData
+
+struct ActivitySessionsListView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+    @Environment(\.dismiss) private var dismiss
+
+    @ObservedObject var activity: Activity
+    @FetchRequest var sessions: FetchedResults<ActivitySession>
+
+    init(activity: Activity) {
+        self.activity = activity
+        _sessions = FetchRequest(fetchRequest: ActivitySession.sessionsForActivityFetchRequest(activity), animation: .default)
+    }
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                if sessions.isEmpty {
+                    EmptyStateView(
+                        icon: "clock",
+                        title: "activity.detail.no_sessions.title",
+                        subtitle: "activity.detail.no_sessions.subtitle"
+                    )
+                    .frame(height: 150)
+                    .padding(DesignSystem.Spacing.md)
+                } else {
+                    LazyVStack(spacing: DesignSystem.Spacing.sm) {
+                        ForEach(sessions, id: \.id) { session in
+                            SessionRowView(session: session)
+                                .padding(.horizontal, DesignSystem.Spacing.md)
+                        }
+                    }
+                    .cardStyle()
+                    .padding(DesignSystem.Spacing.md)
+                }
+            }
+            .background(DesignSystem.Colors.background)
+            .navigationTitle("activity.sessions.title")
+            .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("common.close") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+        .navigationViewStyle(StackNavigationViewStyle())
+    }
+}
+
+struct ActivitySessionsListView_Previews: PreviewProvider {
+    static var previews: some View {
+        let context = PersistenceController.preview.container.viewContext
+        let activity = Activity(context: context)
+        activity.id = UUID()
+        activity.name = "Exercise"
+        activity.type = ActivityType.timer.rawValue
+        activity.color = "#CD3A2E"
+        activity.createdAt = Date()
+        activity.isActive = true
+
+        return ActivitySessionsListView(activity: activity)
+            .environment(\.managedObjectContext, context)
+            .preferredColorScheme(.dark)
+    }
+}

--- a/Localizable.strings
+++ b/Localizable.strings
@@ -34,6 +34,7 @@
 "activity.detail.this_month" = "This Month";
 "activity.detail.recent_sessions" = "Recent Sessions";
 "activity.detail.view_all" = "View All";
+"activity.sessions.title" = "All Sessions";
 "activity.detail.no_sessions.title" = "No Sessions Yet";
 "activity.detail.no_sessions.subtitle" = "Start tracking to see your progress";
 "activity.detail.edit" = "Edit Activity";


### PR DESCRIPTION
## Summary
- create `ActivitySessionsListView` to show all sessions for an activity
- link to sessions list from ActivityDetailView
- localize new title string

## Testing
- `swift --version`
- `swiftc ActivityDetailView.swift ActivitySessionsListView.swift -emit-module -o /tmp/tmpmodule` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6882c4d220a88330ad7face01dc85c97