### PR TITLE
Add CloudKit and widget service tests

### DIFF
--- a/CloudKitServiceTests.swift
+++ b/CloudKitServiceTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+import CoreData
+import CloudKit
+@testable import IntraHabits
+
+final class CloudKitServiceTests: XCTestCase {
+    var service: CloudKitService!
+    var persistence: PersistenceController!
+    var context: NSManagedObjectContext!
+
+    override func setUpWithError() throws {
+        service = CloudKitService.shared
+        persistence = PersistenceController(inMemory: true)
+        context = persistence.container.viewContext
+    }
+
+    override func tearDownWithError() throws {
+        service.disableAutomaticSync()
+        service = nil
+        context = nil
+        persistence = nil
+    }
+
+    func testCloudKitErrorDescriptions() {
+        XCTAssertEqual(CloudKitError.accountNotAvailable.errorDescription, NSLocalizedString("cloudkit.error.account_not_available", comment: ""))
+        XCTAssertEqual(CloudKitError.networkUnavailable.errorDescription, NSLocalizedString("cloudkit.error.network_unavailable", comment: ""))
+        XCTAssertEqual(CloudKitError.quotaExceeded.errorDescription, NSLocalizedString("cloudkit.error.quota_exceeded", comment: ""))
+    }
+
+    func testSyncStatusDisplayText() {
+        XCTAssertEqual(SyncStatus.idle.displayText, NSLocalizedString("sync.status.idle", comment: ""))
+        XCTAssertEqual(SyncStatus.syncing.displayText, NSLocalizedString("sync.status.syncing", comment: ""))
+        XCTAssertEqual(SyncStatus.completed.displayText, NSLocalizedString("sync.status.completed", comment: ""))
+        XCTAssertEqual(SyncStatus.failed.displayText, NSLocalizedString("sync.status.failed", comment: ""))
+    }
+
+    func testMarkObjectsForUploadOnNotification() {
+        let activity = Activity(context: context)
+        activity.id = UUID()
+        activity.name = "Test"
+        activity.type = ActivityType.numeric.rawValue
+        activity.color = "#CD3A2E"
+        activity.createdAt = Date()
+        activity.isActive = true
+        activity.needsCloudKitUpload = false
+        activity.lastModifiedAt = nil
+
+        let notification = Notification(name: .NSManagedObjectContextDidSave, object: context, userInfo: [NSUpdatedObjectsKey: Set([activity])])
+        NotificationCenter.default.post(notification)
+
+        let expectation = XCTestExpectation(description: "Notification handled")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertTrue(activity.needsCloudKitUpload)
+        XCTAssertNotNil(activity.lastModifiedAt)
+    }
+}
+

--- a/WidgetDataServiceTests.swift
+++ b/WidgetDataServiceTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+import CoreData
+@testable import IntraHabits
+
+final class WidgetDataServiceTests: XCTestCase {
+    var service: WidgetDataService!
+    var persistence: PersistenceController!
+    var context: NSManagedObjectContext!
+
+    override func setUpWithError() throws {
+        persistence = PersistenceController(inMemory: true)
+        service = WidgetDataService.shared
+        service.persistentContainer = persistence.container
+        context = persistence.container.viewContext
+    }
+
+    override func tearDownWithError() throws {
+        service = nil
+        context = nil
+        persistence = nil
+    }
+
+    private func createActivity(name: String, type: ActivityType, color: String, active: Bool = true) -> Activity {
+        let activity = Activity(context: context)
+        activity.id = UUID()
+        activity.name = name
+        activity.type = type.rawValue
+        activity.color = color
+        activity.createdAt = Date()
+        activity.isActive = active
+        return activity
+    }
+
+    func testGetAllActivitiesReturnsActiveOnly() async throws {
+        let active = createActivity(name: "Active", type: .numeric, color: "#CD3A2E")
+        let inactive = createActivity(name: "Inactive", type: .numeric, color: "#CD3A2E", active: false)
+        try context.save()
+
+        let activities = try await service.getAllActivities()
+        XCTAssertEqual(activities.count, 1)
+        XCTAssertEqual(activities.first?.id, active.id?.uuidString)
+        XCTAssertFalse(activities.contains { $0.id == inactive.id?.uuidString })
+    }
+
+    func testCreateSessionAndFetchTodaysSessions() async throws {
+        let activity = createActivity(name: "Test", type: .numeric, color: "#CD3A2E")
+        try context.save()
+
+        try await service.createSession(activityId: activity.id!.uuidString, numericValue: 3, duration: nil)
+        let sessions = try await service.getTodaysSessions(for: activity.id!.uuidString)
+
+        XCTAssertEqual(sessions.count, 1)
+        XCTAssertEqual(sessions.first?.numericValue, 3)
+    }
+
+    func testGetTodaysProgressCalculatesTotals() async throws {
+        let activity = createActivity(name: "Progress", type: .numeric, color: "#CD3A2E")
+        try context.save()
+
+        try await service.createSession(activityId: activity.id!.uuidString, numericValue: 2, duration: nil)
+        try await service.createSession(activityId: activity.id!.uuidString, numericValue: 3, duration: nil)
+
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        let oldSession = ActivitySession(context: context)
+        oldSession.id = UUID()
+        oldSession.activity = activity
+        oldSession.sessionDate = yesterday
+        oldSession.numericValue = 5
+        oldSession.isCompleted = true
+        oldSession.createdAt = yesterday
+        try context.save()
+
+        let progress = try await service.getTodaysProgress()
+        XCTAssertEqual(progress.count, 1)
+        let item = progress[0]
+        XCTAssertEqual(item.todaysSessions, 2)
+        XCTAssertEqual(item.todaysNumericTotal, 5)
+        XCTAssertEqual(item.progressPercentage, 1.0, accuracy: 0.001)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `CloudKitServiceTests` for CloudKit error descriptions, sync status strings, and upload marking
- add `WidgetDataServiceTests` for activity retrieval, session creation, and progress calculations

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6882c4d600b48330b78ece6971839938