### PR TITLE
Improve error visibility when loading widget timers

### DIFF
--- a/WidgetTimerService.swift
+++ b/WidgetTimerService.swift
@@ -127,20 +127,24 @@ class WidgetTimerService: ObservableObject {
     
     // MARK: - Persistence
     private func loadTimerStates() {
-        guard let data = userDefaults.data(forKey: "widget_timer_states"),
-              let decoded = try? JSONDecoder().decode([String: TimerStateData].self, from: data) else {
+        guard let data = userDefaults.data(forKey: "widget_timer_states") else {
             return
         }
-        
-        timerStates = decoded.mapValues { data in
-            WidgetTimerState(
-                activityId: data.activityId,
-                isRunning: data.isRunning,
-                isPaused: data.isPaused,
-                startTime: data.startTime,
-                pausedDuration: data.pausedDuration,
-                totalDuration: data.totalDuration
-            )
+
+        do {
+            let decoded = try JSONDecoder().decode([String: TimerStateData].self, from: data)
+            timerStates = decoded.mapValues { data in
+                WidgetTimerState(
+                    activityId: data.activityId,
+                    isRunning: data.isRunning,
+                    isPaused: data.isPaused,
+                    startTime: data.startTime,
+                    pausedDuration: data.pausedDuration,
+                    totalDuration: data.totalDuration
+                )
+            }
+        } catch {
+            AppLogger.error("WidgetTimerService: Failed to decode timer states - \(error.localizedDescription)")
         }
     }
     


### PR DESCRIPTION
## Summary
- add decoding error logging when reading stored timer JSON

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6882c4d5b1cc8330a8660a781d92fd06