### PR TITLE
Add HapticManager and integrate haptics across key actions

### DIFF
--- a/ActivityCard.swift
+++ b/ActivityCard.swift
@@ -201,8 +201,7 @@ class ActivityCardViewModel: ObservableObject {
             
             // Haptic feedback based on value
             let impactStyle: UIImpactFeedbackGenerator.FeedbackStyle = value > 1 ? .heavy : .medium
-            let impactFeedback = UIImpactFeedbackGenerator(style: impactStyle)
-            impactFeedback.impactOccurred()
+            HapticManager.impact(impactStyle)
             
         } catch {
             AppLogger.error("Error saving session: \(error)")

--- a/ActivityDetailView.swift
+++ b/ActivityDetailView.swift
@@ -61,6 +61,7 @@ struct ActivityDetailView: View {
         .alert("activity.delete.confirmation.title", isPresented: $showingDeleteConfirmation) {
             Button("common.cancel", role: .cancel) { }
             Button("common.delete", role: .destructive) {
+                HapticManager.notification(.warning)
                 deleteActivity()
             }
         } message: {
@@ -364,8 +365,7 @@ class ActivityDetailViewModel: ObservableObject {
             loadRecentSessions()
             
             // Haptic feedback
-            let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
-            impactFeedback.impactOccurred()
+            HapticManager.impact(.medium)
 
         } catch {
             AppLogger.error("Error saving session: \(error)")

--- a/ActivityListViewModel.swift
+++ b/ActivityListViewModel.swift
@@ -94,8 +94,7 @@ class ActivityCardViewModel: ObservableObject {
             updateDisplayValues()
             
             // Haptic feedback
-            let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
-            impactFeedback.impactOccurred()
+            HapticManager.impact(.medium)
         } catch {
             AppLogger.error("Error saving session: \(error)")
         }

--- a/AddActivityView.swift
+++ b/AddActivityView.swift
@@ -153,7 +153,8 @@ struct AddActivityView: View {
             Divider()
                 .background(DesignSystem.Colors.systemGray5)
             
-            Button(action: { 
+            Button(action: {
+                HapticManager.impact(.medium)
                 Task {
                     let success = await viewModel.createActivity()
                     if success {
@@ -273,8 +274,7 @@ class AddActivityViewModel: ObservableObject {
             try context.save()
             
             // Haptic feedback
-            let notificationFeedback = UINotificationFeedbackGenerator()
-            notificationFeedback.notificationOccurred(.success)
+            HapticManager.notification(.success)
             
             isLoading = false
             return true

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -268,10 +268,9 @@ class ActivityListViewModel: ObservableObject {
         
         do {
             try context.save()
-            
+
             // Haptic feedback
-            let notificationFeedback = UINotificationFeedbackGenerator()
-            notificationFeedback.notificationOccurred(.success)
+            HapticManager.notification(.success)
             
         } catch {
             errorMessage = error.localizedDescription

--- a/EditActivityView.swift
+++ b/EditActivityView.swift
@@ -275,8 +275,7 @@ class EditActivityViewModel: ObservableObject {
             try context.save()
             
             // Haptic feedback
-            let notificationFeedback = UINotificationFeedbackGenerator()
-            notificationFeedback.notificationOccurred(.success)
+            HapticManager.notification(.success)
             
             isLoading = false
             return true

--- a/HapticManager.swift
+++ b/HapticManager.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+/// Provides simple, centralized access to haptic feedback.
+public enum HapticManager {
+    /// Triggers an impact feedback generator.
+    public static func impact(_ style: UIImpactFeedbackGenerator.FeedbackStyle) {
+        let generator = UIImpactFeedbackGenerator(style: style)
+        generator.prepare()
+        generator.impactOccurred()
+    }
+
+    /// Triggers a notification feedback generator.
+    public static func notification(_ type: UINotificationFeedbackGenerator.FeedbackType) {
+        let generator = UINotificationFeedbackGenerator()
+        generator.prepare()
+        generator.notificationOccurred(type)
+    }
+}

--- a/PaywallView.swift
+++ b/PaywallView.swift
@@ -153,6 +153,7 @@ struct PaywallView: View {
     // MARK: - Purchase Button
     private var purchaseButton: some View {
         Button(action: {
+            HapticManager.impact(.heavy)
             Task {
                 await purchaseManager.purchaseUnlimitedActivities()
             }
@@ -311,6 +312,7 @@ struct PaywallTriggerView: View {
             // Buttons
             VStack(spacing: DesignSystem.Spacing.md) {
                 Button("paywall.upgrade_now") {
+                    HapticManager.impact(.heavy)
                     showingPaywall = true
                 }
                 .buttonStyle(PrimaryButtonStyle())

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -40,6 +40,7 @@ struct SettingsView: View {
         .alert("settings.reset.confirmation.title", isPresented: $showingResetConfirmation) {
             Button("settings.reset.confirmation.cancel", role: .cancel) { }
             Button("settings.reset.confirmation.continue", role: .destructive) {
+                HapticManager.notification(.warning)
                 showingResetFinalConfirmation = true
             }
         } message: {
@@ -48,6 +49,7 @@ struct SettingsView: View {
         .alert("settings.reset.final.title", isPresented: $showingResetFinalConfirmation) {
             Button("settings.reset.final.cancel", role: .cancel) { }
             Button("settings.reset.final.confirm", role: .destructive) {
+                HapticManager.notification(.warning)
                 viewModel.resetAllData()
             }
         } message: {

--- a/StoreKitService.swift
+++ b/StoreKitService.swift
@@ -68,8 +68,7 @@ class StoreKitService: ObservableObject {
                 await transaction.finish()
                 
                 // Haptic feedback
-                let notificationFeedback = UINotificationFeedbackGenerator()
-                notificationFeedback.notificationOccurred(.success)
+                HapticManager.notification(.success)
                 
                 return .success
                 
@@ -97,8 +96,7 @@ class StoreKitService: ObservableObject {
             
             if hasUnlimitedActivities {
                 // Haptic feedback
-                let notificationFeedback = UINotificationFeedbackGenerator()
-                notificationFeedback.notificationOccurred(.success)
+                HapticManager.notification(.success)
                 
                 return .success
             } else {

--- a/TimerView.swift
+++ b/TimerView.swift
@@ -286,8 +286,7 @@ class TimerViewModel: ObservableObject {
         startTimerLoop()
         
         // Haptic feedback
-        let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
-        impactFeedback.impactOccurred()
+        HapticManager.impact(.medium)
     }
     
     func pauseTimer() {
@@ -298,8 +297,7 @@ class TimerViewModel: ObservableObject {
         stopTimerLoop()
         
         // Haptic feedback
-        let impactFeedback = UIImpactFeedbackGenerator(style: .light)
-        impactFeedback.impactOccurred()
+        HapticManager.impact(.light)
     }
     
     func resumeTimer() {
@@ -311,8 +309,7 @@ class TimerViewModel: ObservableObject {
         startTimerLoop()
         
         // Haptic feedback
-        let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
-        impactFeedback.impactOccurred()
+        HapticManager.impact(.medium)
     }
     
     func stopTimer() {
@@ -320,8 +317,7 @@ class TimerViewModel: ObservableObject {
         stopTimerLoop()
         
         // Haptic feedback
-        let impactFeedback = UIImpactFeedbackGenerator(style: .light)
-        impactFeedback.impactOccurred()
+        HapticManager.impact(.light)
     }
     
     func saveSession() {
@@ -346,8 +342,7 @@ class TimerViewModel: ObservableObject {
             pausedDuration = 0
             
             // Haptic feedback
-            let notificationFeedback = UINotificationFeedbackGenerator()
-            notificationFeedback.notificationOccurred(.success)
+            HapticManager.notification(.success)
             
         } catch {
             AppLogger.error("Error saving timer session: \(error)")


### PR DESCRIPTION
## Summary
- introduce `HapticManager` for simple global haptic feedback
- play haptics when creating activities
- trigger warning haptics on destructive actions
- add impact feedback on paywall actions and timer interactions
- replace manual generators with `HapticManager`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6888ce2009088330affb5f5d8bc27cb7