### PR TITLE
Refactor view models and CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,12 +21,10 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    - name: Install SwiftLint
-      run: brew install swiftlint
+    - name: Install SwiftLint and SwiftFormat
+      run: brew install swiftlint swiftformat
     - name: Lint Swift
       run: swiftlint lint --strict
-    - name: Install SwiftFormat
-      run: brew install swiftformat
     - name: Format Swift
       run: swiftformat --lint .
 

--- a/ActivityListViewModel.swift
+++ b/ActivityListViewModel.swift
@@ -3,30 +3,12 @@ import CoreData
 import Combine
 
 class ActivityListViewModel: ObservableObject {
-    @Published var activities: [Activity] = []
-    @Published var isLoading = false
     @Published var errorMessage: String?
-    
+
     private var viewContext: NSManagedObjectContext?
-    private var cancellables = Set<AnyCancellable>()
     
     func setContext(_ context: NSManagedObjectContext) {
         self.viewContext = context
-        loadActivities()
-    }
-    
-    func loadActivities() {
-        guard let context = viewContext else { return }
-        
-        let request: NSFetchRequest<Activity> = Activity.fetchRequest()
-        request.sortDescriptors = [NSSortDescriptor(keyPath: \Activity.sortOrder, ascending: true)]
-        request.predicate = NSPredicate(format: "%K == %@", #keyPath(Activity.isActive), NSNumber(value: true))
-        
-        do {
-            activities = try context.fetch(request)
-        } catch {
-            errorMessage = error.localizedDescription
-        }
     }
     
     func deleteActivity(_ activity: Activity) {
@@ -37,25 +19,23 @@ class ActivityListViewModel: ObservableObject {
         
         do {
             try context.save()
-            loadActivities()
         } catch {
             errorMessage = error.localizedDescription
         }
     }
     
-    func reorderActivities(from source: IndexSet, to destination: Int) {
+    func reorderActivities(from source: IndexSet, to destination: Int, items: [Activity]) {
         guard let context = viewContext else { return }
-        
-        var reorderedActivities = activities
+
+        var reorderedActivities = items
         reorderedActivities.move(fromOffsets: source, toOffset: destination)
-        
+
         for (index, activity) in reorderedActivities.enumerated() {
             activity.sortOrder = Int32(index)
         }
-        
+
         do {
             try context.save()
-            loadActivities()
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/IntraHabitsTests/ActivityListViewModelTests.swift
+++ b/IntraHabitsTests/ActivityListViewModelTests.swift
@@ -8,9 +8,8 @@ final class ActivityListViewModelTests: XCTestCase {
         }
     }
 
-    func testActivityListViewModelFetch() async throws {
+    func testActivityListViewModelInit() throws {
         let vm = ActivityListViewModel()
-        await MainActor.run {}
-        XCTAssertTrue(vm.activities.isEmpty)
+        XCTAssertNil(vm.errorMessage)
     }
 }


### PR DESCRIPTION
## Summary
- decouple state management from `ContentView`
- inject dependencies for `AddActivityViewModel`, `EditActivityViewModel`, and `TimerViewModel`
- simplify `ActivityListViewModel`
- update CI to install lint tools in one step
- adjust tests for new view model API

## Testing
- `swiftformat --lint .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889f0c60bb883309dafd8009af888ec